### PR TITLE
firebase_deploy.ymlファイルでflutterのバージョン指定を追加、main.dartファイルでコメントアウトを削除

### DIFF
--- a/.github/workflows/firebase_deploy.yml
+++ b/.github/workflows/firebase_deploy.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: "stable"
+          # channel: "stable"
+          flutter-version: "3.13.4"
       - run: flutter --version
 
       - name: Install Dependencies

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-// import 'package:flash_pdf_card/startscreen.dart';
 import 'deck_list_view.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase/firebase_options.dart';


### PR DESCRIPTION
.firebase_deploy.yml
- channelプロパティに"stable"を指定
+ flutter-versionプロパティに"3.13.4"を指定

main.dart
- import文をコメントアウトして無効化
+ import文を有効化